### PR TITLE
add IAM password policy enforcement on the preparation account template

### DIFF
--- a/fixtures/buildspec/preparation_account_template.yaml
+++ b/fixtures/buildspec/preparation_account_template.yaml
@@ -105,3 +105,5 @@ phases:
     - echo "Removing obsolete budget names"
     - aws budgets delete-budget --account-id $ACCOUNT --budget-name DataReplyBudget || true
     - aws budgets delete-budget --account-id $ACCOUNT --budget-name StormReplyBudget || true
+    - echo "Enforce IAM password policy"
+    - aws iam update-account-password-policy --minimum-password-length 24 --require-numbers --require-uppercase-characters --require-lowercase-characters --require-symbols --max-password-age 90 --password-reuse-prevention 12 --hard-expiry


### PR DESCRIPTION
Update of default fixtures/buildspec/preparation_account_template.yaml to add an enforce IAM password policy #https://github.com/reply-fr/sustainable-personal-accounts/issues/96

