### PR TITLE
fix: make all-tests failing because of hardcoded region - #136

### DIFF
--- a/tests/test_lambda_e_mail.py
+++ b/tests/test_lambda_e_mail.py
@@ -77,8 +77,12 @@ def test_get_mime_message():
 def test_get_object_as_mime_attachment():
 
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
 
     with pytest.raises(botocore.exceptions.ClientError):  # object does not exist
         Email.get_object_as_mime_attachment(object='s3://my_bucket/some/path/hello.txt')
@@ -101,8 +105,12 @@ def test_get_object_as_mime_attachment():
 def test_send_objects():
 
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
 
     s3.put_object(Bucket="my_bucket",
                   Key='some/path/hello.txt',

--- a/tests/test_lambda_on_account_event_handler.py
+++ b/tests/test_lambda_on_account_event_handler.py
@@ -183,8 +183,12 @@ def test_handle_console_login_event_for_unknown_identity_type():
 def test_handle_report(given_a_table_of_shadows):
     given_a_table_of_shadows()
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
     assert handle_report() == "[OK]"
     response = s3.get_object(Bucket="my_bucket",
                              Key=get_report_path())

--- a/tests/test_lambda_on_activity_handler.py
+++ b/tests/test_lambda_on_activity_handler.py
@@ -102,8 +102,12 @@ def test_handle_record_on_unexpected_environment():
 def test_handle_monthly_report(given_a_table_of_activities):
     given_a_table_of_activities()
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
     assert handle_monthly_report(day=date(year=2023, month=4, day=20)) == "[OK]"
     response = s3.get_object(Bucket="my_bucket",
                              Key=get_report_path(label="DevOps Tools"))
@@ -122,8 +126,12 @@ def test_handle_monthly_report(given_a_table_of_activities):
 def test_handle_ongoing_report(given_a_table_of_activities):
     given_a_table_of_activities()
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
     assert handle_ongoing_report(day=date(year=2023, month=3, day=30)) == "[OK]"
     response = s3.get_object(Bucket="my_bucket",
                              Key=get_report_path(label="DevOps Tools"))

--- a/tests/test_lambda_on_cost_computation_handler.py
+++ b/tests/test_lambda_on_cost_computation_handler.py
@@ -46,8 +46,12 @@ from lambdas.on_cost_computation_handler import (build_charge_reports_per_cost_c
 @mock_aws
 def test_build_charge_reports_per_cost_center(sample_chunk_monthly_charges_per_account, sample_accounts):
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
 
     day = date(2023, 3, 31)
     mock = Mock()
@@ -61,8 +65,12 @@ def test_build_charge_reports_per_cost_center(sample_chunk_monthly_charges_per_a
 @mock_aws
 def test_build_service_reports_per_cost_center(sample_chunk_monthly_services_per_account, sample_accounts):
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
 
     day = date(2023, 3, 31)
     mock = Mock()
@@ -76,8 +84,12 @@ def test_build_service_reports_per_cost_center(sample_chunk_monthly_services_per
 @mock_aws
 def test_build_usage_reports_per_cost_center(sample_chunk_monthly_usages_per_account, sample_accounts):
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
 
     day = date(2023, 3, 31)
     mock = Mock()
@@ -95,8 +107,12 @@ def test_email_reports():
     path = get_report_path(cost_center='Summary', label='services', day=day, suffix='test')
 
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
 
     s3.put_object(Bucket="my_bucket",
                   Key=path,
@@ -150,6 +166,10 @@ def test_get_report_path():
 @mock_aws
 def test_store_report():
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
     store_report(path="path/hello.txt", report="hello world") == '[OK]'

--- a/tests/test_lambda_on_exception_handler.py
+++ b/tests/test_lambda_on_exception_handler.py
@@ -55,8 +55,12 @@ sample_payload = json.dumps(
 def test_handle_exception():
 
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
 
     ssm = boto3.client("ssm")
     ssm.put_parameter(Name='my_endpoints',
@@ -132,8 +136,12 @@ def test_get_report_path():
 @mock_aws
 def test_store_report():
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
     store_report(path="path/hello.txt", report="hello world") == '[OK]'
 
 
@@ -145,8 +153,12 @@ def test_store_report():
 def test_handle_attachment_request():
 
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
     s3.put_object(Bucket="my_bucket", Key="exceptions/my/test.csv", Body="hello,world\nhello,universe")
 
     with open('fixtures/events/sample_direct_download_request.json') as stream:
@@ -166,8 +178,12 @@ def test_handle_attachment_request():
 def test_download_attachment():
 
     s3 = boto3.client("s3")
-    s3.create_bucket(Bucket="my_bucket",
-                     CreateBucketConfiguration=dict(LocationConstraint='eu-west-3'))
+    region = s3.meta.region_name
+    create_bucket_config = {
+        "CreateBucketConfiguration": dict(LocationConstraint=region)
+    } if region != "us-east-1" else {}
+
+    s3.create_bucket(Bucket="my_bucket", **create_bucket_config)
     s3.put_object(Bucket="my_bucket", Key="exceptions/my/test.csv", Body="hello,world\nhello,universe")
 
     sec_fetch_headers = {


### PR DESCRIPTION
This solution takes into account the fact that potential users could have the region `eu-west-3` deactivated, else another option would have been to simply overwrite the s3 boto3 client with the `eu-west-3` region.

Closes issue #136