### PR TITLE
Allow bedrock invokation on unmanaged control tower regions

### DIFF
--- a/fixtures/policies/preventive_controls_for_sandboxes.json
+++ b/fixtures/policies/preventive_controls_for_sandboxes.json
@@ -7,7 +7,7 @@
       "Action": "*",
       "Resource": "*",
       "Condition": {
-        "StringLike": {
+        "ArnLike": {
           "aws:PrincipalArn": [
             "arn:aws:iam::*:root"
           ]
@@ -15,31 +15,111 @@
       }
     },
     {
-      "Sid": "SpaDenyAllOutsideRequestedRegions",
+      "Condition": {
+        "StringNotEquals": {
+          "aws:RequestedRegion": [
+            "eu-west-3",
+            "eu-north-1",
+            "eu-west-2",
+            "eu-west-1",
+            "eu-central-1",
+            "us-east-1",
+            "ap-east-1"
+          ]
+        },
+        "ArnNotLike": {
+          "aws:PrincipalARN": [
+            "arn:*:iam::*:role/AWSControlTowerExecution"
+          ]
+        }
+      },
+      "Resource": "*",
       "Effect": "Deny",
       "NotAction": [
-          "cloudfront:*",
-          "iam:*",
-          "route53:*",
-          "support:*"
+        "a4b:*",
+        "access-analyzer:*",
+        "account:*",
+        "acm:*",
+        "activate:*",
+        "artifact:*",
+        "aws-marketplace-management:*",
+        "aws-marketplace:*",
+        "aws-portal:*",
+        "billing:*",
+        "billingconductor:*",
+        "budgets:*",
+        "ce:*",
+        "chatbot:*",
+        "chime:*",
+        "cloudfront:*",
+        "cloudtrail:LookupEvents",
+        "compute-optimizer:*",
+        "config:*",
+        "consoleapp:*",
+        "consolidatedbilling:*",
+        "cur:*",
+        "datapipeline:GetAccountLimits",
+        "devicefarm:*",
+        "ecr-public:*",
+        "fms:*",
+        "freetier:*",
+        "globalaccelerator:*",
+        "health:*",
+        "iam:*",
+        "importexport:*",
+        "invoicing:*",
+        "iq:*",
+        "kms:*",
+        "license-manager:ListReceivedLicenses",
+        "lightsail:Get*",
+        "mobileanalytics:*",
+        "networkmanager:*",
+        "notifications-contacts:*",
+        "notifications:*",
+        "organizations:*",
+        "payments:*",
+        "pricing:*",
+        "quicksight:DescribeAccountSubscription",
+        "resource-explorer-2:*",
+        "route53-recovery-cluster:*",
+        "route53-recovery-control-config:*",
+        "route53-recovery-readiness:*",
+        "route53:*",
+        "route53domains:*",
+        "s3:CreateMultiRegionAccessPoint",
+        "s3:DeleteMultiRegionAccessPoint",
+        "s3:DescribeMultiRegionAccessPointOperation",
+        "s3:GetAccountPublicAccessBlock",
+        "s3:GetBucketLocation",
+        "s3:GetBucketPolicyStatus",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetMultiRegionAccessPoint",
+        "s3:GetMultiRegionAccessPointPolicy",
+        "s3:GetMultiRegionAccessPointPolicyStatus",
+        "s3:GetStorageLensConfiguration",
+        "s3:GetStorageLensDashboard",
+        "s3:ListAllMyBuckets",
+        "s3:ListMultiRegionAccessPoints",
+        "s3:ListStorageLensConfigurations",
+        "s3:PutAccountPublicAccessBlock",
+        "s3:PutMultiRegionAccessPointPolicy",
+        "savingsplans:*",
+        "shield:*",
+        "sso:*",
+        "sts:*",
+        "support:*",
+        "supportapp:*",
+        "supportplans:*",
+        "sustainability:*",
+        "tag:GetResources",
+        "tax:*",
+        "trustedadvisor:*",
+        "vendor-insights:ListEntitledSecurityProfiles",
+        "waf-regional:*",
+        "waf:*",
+        "wafv2:*"
       ],
-      "Resource": "*",
-      "Condition": {
-          "StringNotEquals": {
-              "aws:RequestedRegion": [
-                  "ap-east-1",
-                  "ap-southeast-1",
-                  "eu-central-1",
-                  "eu-west-1",
-                  "eu-west-3",
-                  "us-east-1",
-                  "us-west-2"
-              ]
-          },
-          "ArnNotLike": {
-            "aws:PrincipalARN": "arn:aws:iam::*:role/AWSControlTowerExecution"
-          }
-      }
+      "Sid": "GRREGIONDENY"
     },
     {
       "Sid": "SpaDenyCreationOfCostlyResources",
@@ -78,14 +158,14 @@
       "Sid": "SpaDenyResourceShareOutsideOrganization",
       "Effect": "Deny",
       "Action": [
-          "ram:CreateResourceShare",
-          "ram:UpdateResourceShare"
+        "ram:CreateResourceShare",
+        "ram:UpdateResourceShare"
       ],
       "Resource": "*",
       "Condition": {
-          "Bool": {
-              "ram:RequestedAllowsExternalPrincipals": "true"
-          }
+        "Bool": {
+          "ram:RequestedAllowsExternalPrincipals": "true"
+        }
       }
     },
     {

--- a/fixtures/policies/preventive_controls_for_sandboxes.json
+++ b/fixtures/policies/preventive_controls_for_sandboxes.json
@@ -117,7 +117,8 @@
         "vendor-insights:ListEntitledSecurityProfiles",
         "waf-regional:*",
         "waf:*",
-        "wafv2:*"
+        "wafv2:*",
+        "bedrock:Invoke*"
       ],
       "Sid": "GRREGIONDENY"
     },


### PR DESCRIPTION
Edited the SCP "SpaScpForSandboxes" applied to the "sandbox" OU:

-  Based on this Control Tower official guardrail (https://docs.aws.amazon.com/controltower/latest/controlreference/primary-region-deny-policy.html)
- Added a statement to allow bedrock model invokation outside of the landing zone enrolled regions. 